### PR TITLE
Remove unused KUSAMA_ACCOUNT_SEED references

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ Alternatively, create `.env` file manually:
 
 - `KUSAMA_ENDPOINT` - Kusama RPC endpoint (default: wss://kusama-rpc.polkadot.io)
 - `KUSAMA_ACCOUNT_TYPE` - Account type: sr25519, ed25519, or ecdsa (default: sr25519)
-- `KUSAMA_ACCOUNT_SEED` - 64-character hex seed for your Kusama account
 
 **Optional Configuration:**
 
@@ -1114,8 +1113,7 @@ npm run format          # Auto-format code
    # Generate session secret
    node -e "console.log('SESSION_SECRET=' + require('crypto').randomBytes(32).toString('base64'))"
 
-   # Generate Kusama account seed
-   node -e "console.log('KUSAMA_ACCOUNT_SEED=' + require('crypto').randomBytes(32).toString('hex'))"
+
    ```
 
 2. **Set Production Environment Variables**:

--- a/src/services/kusamaIntegrationService.ts
+++ b/src/services/kusamaIntegrationService.ts
@@ -29,7 +29,6 @@ export class KusamaIntegrationService {
     // Debug environment variables
     console.log('🔍 Debug - Environment variables:');
     console.log('KUSAMA_ENDPOINT:', process.env.KUSAMA_ENDPOINT);
-    console.log('KUSAMA_ACCOUNT_SEED:', process.env.KUSAMA_ACCOUNT_SEED);
     console.log('KUSAMA_ACCOUNT_TYPE:', process.env.KUSAMA_ACCOUNT_TYPE);
   }
 


### PR DESCRIPTION
- Remove KUSAMA_ACCOUNT_SEED from README environment configuration
- Remove KUSAMA_ACCOUNT_SEED generation command from README
- Remove KUSAMA_ACCOUNT_SEED debug logging from KusamaIntegrationService
- System now uses wallet-based authentication instead of seed phrases